### PR TITLE
#87/integrate textsearch

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,38 +1,6 @@
-.App {
-  text-align: center;
-}
-
-.App-logo {
-  height: 40vmin;
-  pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  .App-logo {
-    animation: App-logo-spin infinite 20s linear;
-  }
-}
-
-.App-header {
-  background-color: #282c34;
-  min-height: 100vh;
-  display: flex;
+.app {
+  display:flex;
   flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  font-size: calc(10px + 2vmin);
-  color: white;
-}
-
-.App-link {
-  color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+  width: 100vw;
+  height: 100vh;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,56 +1,22 @@
-import './App.css';
-import Dropdown from './components/Dropdown';
-import ClusterCard from './components/ClusterCard'
-import fetchAllRoutes from './utils/fetchAllRoutes';
-import fetchOccupationByQuery from './utils/fetchOccupationByQuery'
-import { useEffect, useState } from 'react';
-import Header from './components/Header';
+import "./style/globals.css"
+import fetchOccupationByQuery from "./utils/fetchOccupationByQuery"
+import { useEffect, useState } from "react"
+import Header from "./components/Header"
 
 function App() {
-  const [allRoutes, setAllRoutes] = useState([])
-  const [selectedRoute, setSelectedRoute] = useState("")
-  const [routeDetails, setRouteDetails] = useState(null)
+  const [searchResults, setSearchResults] = useState(undefined)
 
-  useEffect(() => {
-    const fetch = async () => {
-      try {
-        const fetchedRoutes = await fetchAllRoutes()
-        setAllRoutes(fetchedRoutes)
-      } catch (error) {
-        console.error("Failed to fetch routes:", error)
-      }
-    }
-    fetch()
-  }, [])
-
-  useEffect(() => {
-    if (selectedRoute) {
-      const route = allRoutes.find((route) => route.routeId === parseInt(selectedRoute, 10));
-      setRouteDetails(route);
-    }
-  }, [selectedRoute, allRoutes])
+  const handleSearch = async query => {
+    const data = await fetchOccupationByQuery(query)
+    setSearchResults(data)
+  }
 
   return (
     <div className="App">
-      <Header searchHandler={fetchOccupationByQuery} />
-      <h1>Route Details</h1>
-      <Dropdown
-        routes={allRoutes}
-        selectedRoute={selectedRoute}
-        setSelectedRoute={setSelectedRoute}
-        showId={false}
-      />
-      {routeDetails ? (
-          <ClusterCard
-            name={routeDetails.name}
-            description={`ID: ${routeDetails.routeId}`}
-            technicalLevelName={`Technical Level: ${routeDetails.technicalLevelName || 'N/A'}`}
-          />
-      ) : (
-        <div>Select a route to see details.</div>
-      )}
+      <Header searchHandler={handleSearch} />
+      {searchResults && <p>{searchResults.results[0].object}</p>}
     </div>
   )
 }
 
-export default App;
+export default App

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import './App.css';
 import Dropdown from './components/Dropdown';
 import ClusterCard from './components/ClusterCard'
 import fetchAllRoutes from './utils/fetchAllRoutes';
+import fetchOccupationByQuery from './utils/fetchOccupationByQuery'
 import { useEffect, useState } from 'react';
 import Header from './components/Header';
 
@@ -31,7 +32,7 @@ function App() {
 
   return (
     <div className="App">
-      <Header />
+      <Header searchHandler={fetchOccupationByQuery} />
       <h1>Route Details</h1>
       <Dropdown
         routes={allRoutes}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -16,7 +16,7 @@ function App() {
   return (
     <div className="app">
       <Header searchHandler={handleSearch} />
-      {searchResults && <p>{searchResults.results[0].object}</p>}
+      {searchResults && <p>{searchResults.results.map(result => <p>{result.name}</p>)}</p>}
     </div>
   )
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,7 +1,9 @@
-import "./style/globals.css"
 import fetchOccupationByQuery from "./utils/fetchOccupationByQuery"
-import { useEffect, useState } from "react"
+import { useState } from "react"
 import Header from "./components/Header"
+
+import './style/globals.css'
+import './App.css'
 
 function App() {
   const [searchResults, setSearchResults] = useState(undefined)
@@ -12,7 +14,7 @@ function App() {
   }
 
   return (
-    <div className="App">
+    <div className="app">
       <Header searchHandler={handleSearch} />
       {searchResults && <p>{searchResults.results[0].object}</p>}
     </div>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -10,9 +10,7 @@ export default function Header({ searchHandler }) {
       </div>
       <TextSearch searchHandler={searchHandler} />
       <div className="button-container">
-        <a className="header-button">
-          About
-        </a>
+        <a className="header-button">About</a>
         <a className="header-button" type="button">
           Search
         </a>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,17 +1,22 @@
-import gatsbyLogo from "../images/GATSBY.jpeg";
-import "../style/Header.css";
+import TextSearch from "./TextSearch"
+import gatsbyLogo from "../images/GATSBY.jpeg"
+import "../style/Header.css"
 
-export default function Header() {
+export default function Header({ searchHandler }) {
   return (
     <header className="header">
       <div className="logo-container">
         <img src={gatsbyLogo} alt="Gatsby Logo" className="logo" />
       </div>
-      <input type="text" placeholder="Search a pathway" className="search-bar" />
+      <TextSearch searchHandler={searchHandler} />
       <div className="button-container">
-        <button className="header-button">About</button>
-        <button className="header-button">Search</button>
+        <a className="header-button">
+          About
+        </a>
+        <a className="header-button" type="button">
+          Search
+        </a>
       </div>
     </header>
-  );
+  )
 }

--- a/frontend/src/components/Header.stories.js
+++ b/frontend/src/components/Header.stories.js
@@ -1,7 +1,11 @@
 import Header from './Header';
+import {fn} from '@storybook/test'
 
 export default {
     title:'Header',
     component: Header,
+    args:{
+        searchHandler: fn()
+    }
 };
 export const DefaultHeader = {}

--- a/frontend/src/style/Header.css
+++ b/frontend/src/style/Header.css
@@ -1,5 +1,5 @@
 .header {
-  width: 90vw;
+  width: 98vw;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/frontend/src/style/Header.css
+++ b/frontend/src/style/Header.css
@@ -29,16 +29,17 @@
 
 .button-container {
   display: flex;
+  flex-direction: row;
   align-items: center;
+  justify-content: space-between;
+  width: 10rem;
 }
 
 .header-button {
   background: none;
   border: none;
   color: white;
-  font-size: 16px;
   cursor: pointer;
-  padding: 5px 10px;
 }
 
 .header-button:hover {

--- a/frontend/src/utils/fetchOccupationByQuery.js
+++ b/frontend/src/utils/fetchOccupationByQuery.js
@@ -1,5 +1,5 @@
 /**
- * 
+ *
  * @param {string} givenQuery a string with any search parameter
  * @returns {Promise<Array<object>>} returns a fulfilled promise with an array of Occupation objects from the API when successful
  * @returns {error} returns an error object if unfulfilled
@@ -18,10 +18,9 @@ export default async function fetchOccupationByQuery(givenQuery) {
     throw new Error("No search parameter found")
 
   try {
-    const { data, error } = await fetch(
+    const data = await fetch(
       `${process.env.REACT_APP_SERVER}/getOccupationByQuery/${givenQuery}`
     )
-    if (error) throw error
     const parsedData = await data.json()
     return parsedData
   } catch (error) {


### PR DESCRIPTION
Re-arranged the landing page so that now users can in fact search for any occupations by entering a text query and a list of results will be set in our state.

## File changes
- `App.jsx` - removed a lot of clutter we had from our mocking before and left only the header and simple state being displayed for now in a placeholder where the `OccupationsList.jsx` will go
- `App.css` - cleared all the original styling and set up just a basic class for the full wrapper around our app
- `Header.jsx` - now integrates the `TextSearch.jsx` component so it needed some refactoring to consider this as well
- `FetchOccupationByQuery.js` - needed a fix on the error handling to work in the full integration
- `Header.stories.js` and `Header.css` - for style editing and extended testing of the component