### PR TITLE
fix: add frontend to cors as env variable for multiple environments

### DIFF
--- a/backend/server/server.js
+++ b/backend/server/server.js
@@ -9,7 +9,7 @@ import getOccupationByQuery from "./routes/getOccupationByQuery.js"
 const server = express()
 
 const corsOptions = {
-    origin: "http://localhost:3000",
+    origin: process.env.FRONTEND,
     optionsSuccessStatus: 200,
 }
 


### PR DESCRIPTION
relates #69

# Description

**Relates #69 **  

Abstracted the reference to the frontend in CORS to an env variable to allow for our different environments to deploy.

### Files changed

- `backend/server/server.js`

### UI changes

None

### Changes to Documentation

None

# Tests

None 
