### PR TITLE
#154/test occupation details

### DIFF
--- a/frontend/cypress/e2e/navigation.cy.js
+++ b/frontend/cypress/e2e/navigation.cy.js
@@ -1,0 +1,31 @@
+import * as page from "../fixtures/URLs.json"
+import * as input from "../fixtures/inputs.json"
+import HomePage from "../support/page_objects/HomePage"
+import SearchPage from "../support/page_objects/SearchPage"
+import AboutPage from "../support/page_objects/AboutPage"
+import DetailsPage from "../support/page_objects/DetailsPage"
+
+describe("Navigation feature", () => {
+  it("allows the user to visit '/about' page", () => {
+    cy.visit(page.home)
+    HomePage.linkToAbout().click()
+    cy.url().should("include", "/about")
+    AboutPage.stockPhoto()
+    AboutPage.textCopy()
+  })
+
+  it("allows the user to find details about any given occupation", () => {
+    cy.visit(page.search)
+    SearchPage.searchBar().type(input.searchSingle)
+    SearchPage.searchButton().click()
+    SearchPage.occupationCard()
+      .contains(/software/i)
+      .click()
+    cy.url().should("contain", "/occupation-details")
+    DetailsPage.occupationTitle().contains(
+      /software development technician/i
+    )
+    DetailsPage.occupationOverview().contains(/software development/i)
+    DetailsPage.tLevelCard().contains(/digital production/i)
+  })
+})

--- a/frontend/cypress/support/page_objects/AboutPage.js
+++ b/frontend/cypress/support/page_objects/AboutPage.js
@@ -1,10 +1,17 @@
 import PageLayout from "./PageLayout"
 
 class AboutPage extends PageLayout {
-  header() {
+  stockPhoto() {
     return cy
-      .get("h1")
-      .contains(/about page/i)
+      .get("main")
+      .find("img")
+      .should("be.visible")
+      .and("have.prop", "src")
+  }
+
+  textCopy() {
+    return cy
+      .get("div[class='about-page-container__element'] > p")
       .should("be.visible")
   }
 }

--- a/frontend/cypress/support/page_objects/DetailsPage.js
+++ b/frontend/cypress/support/page_objects/DetailsPage.js
@@ -1,0 +1,17 @@
+import PageLayout from "./PageLayout"
+
+class DetailsPage extends PageLayout {
+  occupationTitle() {
+    return cy.get(".occupation-header h1").should("be.visible")
+  }
+
+  occupationOverview() {
+    return cy.get(".occupation-page__banner p").should("be.visible")
+  }
+
+  tLevelCard() {
+    return cy.get(".t-level-card p").should("be.visible")
+  }
+}
+
+export default new DetailsPage()

--- a/frontend/cypress/support/page_objects/SearchPage.js
+++ b/frontend/cypress/support/page_objects/SearchPage.js
@@ -9,9 +9,13 @@ class SearchPage extends PageLayout {
   }
 
   heartIcon() {
-    return cy
-      .get('svg[class="heart-icon"]')
-      .should("be.visible")
+    return cy.get('svg[class="heart-icon"]').should("be.visible")
+  }
+
+  occupationCard() {
+    return cy.get("button[class='occupation-card']").first().should(
+      "be.visible"
+    )
   }
 }
 


### PR DESCRIPTION
# Description

**Closes #154**  

Adds a new suite to our end to end tests checking the navigation feature.

### Files changed

- `navigation.cy.js` - new test suite checking users can click through to the `/about` page and `/occupation-details` page
- `cypress/**`- support files for our end to end testing

### UI changes

none

### Changes to Documentation

none

# Tests

Testing pr. All changes documented above
