### PR TITLE
#153/style layout

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,16 @@
 .app {
-  display:flex;
-  flex-direction: column;
   width: 100dvw;
   height: 100dvh;
+  display: grid;
+  grid-template-rows: auto 1fr;
+}
+
+.app--header {
+  grid-row: 1;
+  z-index: 30;
+}
+
+.app--routes {
+  overflow-y: auto;
+  height: 100%;
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -14,7 +14,7 @@ import "./App.css"
 
 function App() {
   const [searchStatus, setSearchStatus] = useState("idle")
-  const [searchQuery, setSearchQuery] = useState('')
+  const [searchQuery, setSearchQuery] = useState("")
   const [searchResults, setSearchResults] = useState([])
   const navigate = useNavigate()
 
@@ -32,7 +32,7 @@ function App() {
       }
     }
 
-    if (searchQuery !== '') {
+    if (searchQuery !== "") {
       handleSearch()
     } else {
       setSearchStatus("idle")
@@ -45,29 +45,30 @@ function App() {
 
   return (
     <div className="app">
-      <Header searchHandler={handleQuery} />
+      <div className="app--header">
+        <Header searchHandler={handleQuery} />
+      </div>
 
-      <Routes>
-        <Route path='/' element={<InfoPage />} />
-        <Route path="/about" element={<About />} />
-        <Route
-          path="/search"
-          element={
-            <Search
-              searchResults={searchResults}
-              searchStatus={searchStatus}
-              searchQuery={searchQuery}
-            />
-          }
-        />
-        <Route
-          path="/occupation-details/:occupation"
-          element={
-            <OccupationPage
-              searchResults={searchResults}
-            />}
-        />
-      </Routes>
+      <div className="app--routes">
+        <Routes>
+          <Route path="/" element={<InfoPage />} />
+          <Route path="/about" element={<About />} />
+          <Route
+            path="/search"
+            element={
+              <Search
+                searchResults={searchResults}
+                searchStatus={searchStatus}
+                searchQuery={searchQuery}
+              />
+            }
+          />
+          <Route
+            path="/occupation-details/:occupation"
+            element={<OccupationPage searchResults={searchResults} />}
+          />
+        </Routes>
+      </div>
     </div>
   )
 }

--- a/frontend/src/components/InfoPage.jsx
+++ b/frontend/src/components/InfoPage.jsx
@@ -5,7 +5,7 @@ function InfoPage() {
   
 
   return (
-    <main className="main-section" style={{ backgroundImage: `url(${backgroundImage})` }}>
+    <main className="info-page main" style={{ backgroundImage: `url(${backgroundImage})` }}>
       <div className="info-page__wrapper">
         <h1 className='info-page__text'> 
           T-Level stuff

--- a/frontend/src/components/InfoPage.jsx
+++ b/frontend/src/components/InfoPage.jsx
@@ -2,20 +2,17 @@ import "../style/InfoPage.css"
 import backgroundImage from "../images/HomeBackground.jpg"
 
 function InfoPage() {
-  
-
   return (
-    <main className="info-page main" style={{ backgroundImage: `url(${backgroundImage})` }}>
+    <main
+      className="info-page main"
+      style={{ backgroundImage: `url(${backgroundImage})` }}
+    >
       <div className="info-page__wrapper">
-        <h1 className='info-page__text'> 
-          T-Level stuff
-        </h1>
-        <p className="info-page__text">
-          All In One Place
-        </p>
+        <h1 className="info-page__text">Pathways</h1>
+        <p className="info-page__text">Explore T-Level placements for team</p>
       </div>
     </main>
-  );
+  )
 }
 
-export default InfoPage;
+export default InfoPage

--- a/frontend/src/components/OccupationsList.jsx
+++ b/frontend/src/components/OccupationsList.jsx
@@ -3,9 +3,9 @@ import "../style/OccupationsList.css"
 
 export default function OccupationsList({ occupationsArray }) {
   return (
-    <div className="container">
+    <div className="occupations-list--container">
       {occupationsArray.length === 0 ? (
-        <p>There are no occupations matching your search terms</p>
+        <p className="occupations-list__empty">There are no occupations matching your search terms</p>
       ) : (
         occupationsArray.map(occupation => (
           <OccupationCard

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -15,7 +15,7 @@ export default function OccupationPage({ searchResults }) {
     ""
   )
   return (
-    <main className="occupation-page__main">
+    <main className="occupation-page__main main">
       <div className="flex-col occupation-header">
         <h1>{searchResults[index].name}</h1>
         <h2>

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -104,7 +104,9 @@ export default function Search({
           </p>
         )}
       </div>
-      <div className="search-page--results">{renderStatusResults()}</div>
+      <div className="search-page--results">
+        {renderStatusResults()}
+      </div>
     </div>
   )
 }

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -89,8 +89,7 @@ export default function Search({
   }
 
   return (
-    <>
-      <h1>Search Page</h1>
+    <div className="search-page main">
       <div className="search-page--options-bar">
         <div>
           <FilterButton
@@ -105,7 +104,7 @@ export default function Search({
           </p>
         )}
       </div>
-      {renderStatusResults()}
-    </>
+      <div className="search-page--results">{renderStatusResults()}</div>
+    </div>
   )
 }

--- a/frontend/src/style/InfoPage.css
+++ b/frontend/src/style/InfoPage.css
@@ -1,16 +1,16 @@
 .info-page {
   background: url("../images/HomeBackground.jpg") center center/cover
-  no-repeat;
+    no-repeat;
   display: flex;
   justify-content: center;
   align-items: center;
   height: 80dvh;
   width: 95dvw;
-  margin:0 2.5dvw;
+  margin: 0 2.5dvw;
   padding: 1rem 1rem;
 }
 
-.main-section .info-page__wrapper {
+.info-page__wrapper {
   background: rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;
@@ -21,21 +21,20 @@
   padding: 0.5rem 1rem;
 }
 
-.info-page__wrapper .info-page__text {
+.info-page__text {
   background-color: rgba(126, 126, 126, 0.5);
   padding: 0.3rem 5rem;
   height: fit-content;
 }
 
-.main-section .info-page__wrapper h1 {
+.info-page__wrapper h1 {
   font-size: 5rem;
-
   margin: 0;
   align-content: center;
   height: 12rem;
 }
 
-.main-section .info-page__wrapper p {
+.info-page__wrapper p {
   font-size: 2rem;
   margin: 4rem 0 0;
 }

--- a/frontend/src/style/InfoPage.css
+++ b/frontend/src/style/InfoPage.css
@@ -1,23 +1,16 @@
-.main-section {
-  position: relative;
-  height: 100dvh;
+.info-page {
   background: url("../images/HomeBackground.jpg") center center/cover
-    no-repeat;
+  no-repeat;
   display: flex;
   justify-content: center;
   align-items: center;
-  width: 85dvw;
+  height: 80dvh;
+  width: 95dvw;
+  margin:0 2.5dvw;
   padding: 1rem 1rem;
-  margin-top: 3rem;
-  margin-bottom: 2rem;
 }
 
 .main-section .info-page__wrapper {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
   background: rgba(0, 0, 0, 0.2);
   display: flex;
   flex-direction: column;

--- a/frontend/src/style/OccupationsList.css
+++ b/frontend/src/style/OccupationsList.css
@@ -1,9 +1,20 @@
-.container {
-  display: flex;
-  flex-direction: column;
-  gap:1rem;
-  width: 28dvw;
-  height: 85dvh;
+.occupations-list--container {
+  display: grid;
+  grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+  gap: 1rem;
+  height: 100%;
+  width: 100%;
   padding: 5px;
-  overflow: auto;
+}
+
+.occupations-list--container > *:only-child {
+  grid-column: 2 / 3;
+  grid-row: 2 / 3;
+  justify-self: center;
+  align-self: center;
+}
+
+.occupations-list__empty {
+  grid-row: 2;
+  grid-column: 2;
 }

--- a/frontend/src/style/OccupationsList.css
+++ b/frontend/src/style/OccupationsList.css
@@ -7,7 +7,18 @@
   padding: 5px 15px;
 }
 
+.occupations-list--container > .occupation-card {
+  opacity: 0;
+  animation: fadeIn 0.2s ease-in-out forwards;
+}
+
 .occupations-list__empty {
   grid-row: 2;
   grid-column: 2;
+}
+
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
 }

--- a/frontend/src/style/OccupationsList.css
+++ b/frontend/src/style/OccupationsList.css
@@ -1,17 +1,10 @@
 .occupations-list--container {
   display: grid;
-  grid-template: repeat(3, 1fr) / repeat(3, 1fr);
+  grid-template: repeat(3, auto) / repeat(3, auto);
   gap: 1rem;
   height: 100%;
-  width: 100%;
-  padding: 5px;
-}
-
-.occupations-list--container > *:only-child {
-  grid-column: 2 / 3;
-  grid-row: 2 / 3;
-  justify-self: center;
-  align-self: center;
+  width: fit-content;
+  padding: 5px 15px;
 }
 
 .occupations-list__empty {

--- a/frontend/src/style/OccupationsList.css
+++ b/frontend/src/style/OccupationsList.css
@@ -22,3 +22,19 @@
     opacity: 1;
   }
 }
+
+@media (max-width: 1400px) {
+  .occupations-list--container {
+    border: 2px solid pink;
+    display: grid;
+    grid-template: repeat(2, auto) / repeat(2, auto);
+  }
+}
+
+@media (max-width: 800px) {
+  .occupations-list--container {
+    border: 2px solid pink;
+    display: grid;
+    grid-template: repeat(1, auto) / repeat(1, auto);
+  }
+}

--- a/frontend/src/style/Search.css
+++ b/frontend/src/style/Search.css
@@ -11,7 +11,8 @@
   flex-direction: row-reverse;
   justify-content: space-between;
   align-items: center;
-  width: 70dvw;
+  width: 100dvw;
+  padding:15px;
   grid-row: 1;
 }
 

--- a/frontend/src/style/Search.css
+++ b/frontend/src/style/Search.css
@@ -12,7 +12,7 @@
   justify-content: space-between;
   align-items: center;
   width: 100dvw;
-  padding:15px;
+  padding: 15px;
   grid-row: 1;
 }
 
@@ -29,4 +29,5 @@
   height: 100%;
   width: 100%;
   overflow-y: auto;
+  justify-content: center;
 }

--- a/frontend/src/style/Search.css
+++ b/frontend/src/style/Search.css
@@ -1,9 +1,18 @@
+.search-page {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  align-items: center;
+  justify-content: space-around;
+  gap: 35px;
+}
+
 .search-page--options-bar {
   display: flex;
   flex-direction: row-reverse;
   justify-content: space-between;
   align-items: center;
   width: 70dvw;
+  grid-row: 1;
 }
 
 .search-page--options-button {
@@ -12,4 +21,11 @@
   background: none;
   border: none;
   cursor: pointer;
+}
+
+.search-page--results {
+  grid-row: 2;
+  height: 100%;
+  width: 100%;
+  overflow-y: auto;
 }

--- a/frontend/src/style/globals.css
+++ b/frontend/src/style/globals.css
@@ -32,6 +32,12 @@
   display: flex;
 }
 
+.main {
+  grid-row:2;
+  height: 100%;
+  width: 100dvw;
+}
+
 @media (min-width: 800px) {
   p,
   span,


### PR DESCRIPTION
# Description

**Closes #153 && Closes #159**  

This is a large one by file count but it only doing two simple things:

- set the general layout so that our header is always fixed at the top of the page and pages scroll behind it if needed
- corrected the occupations list layout to be a grid (I tackled this issue in the same pr because I was having to touch all the files relevant already as part of the general layout re-styling)

### Files changed

- `frontend/src/pages/**[.jsx || .css]` - edited styling within our different pages and renamed some classes to avoid clashing
- `globals.css` && `app.css` - lifted some styling up to global classes or app styling to avoid it being repeated all over the code base. Now the class `.main` can just be popped into any page file (on the outermost element) and will force it to sit nicely in the second column of our app without fighting with the header for space
- `OccupationsList.jsx` && `OccupationsList.css` - now showing results in a grid with a slight fade in effect for the cards

### UI changes

## Occupations List is a grid
<img width="1462" alt="Screenshot 2024-08-23 at 12 07 03" src="https://github.com/user-attachments/assets/f924fbee-aacc-432a-97f1-62e1145414c8">

## Pages scroll below the Header if needed
<img width="1456" alt="Screenshot 2024-08-23 at 12 07 46" src="https://github.com/user-attachments/assets/fd6a5f02-6a1d-428a-ab17-9eb4211e4059">

### Changes to Documentation

None

# Tests

No changes needed. All tests passing
![Screenshot 2024-08-23 at 12 08 31](https://github.com/user-attachments/assets/0ac5da03-6f15-410e-92a0-09da687773b8)

