### PR TITLE
#180/search query fix

### DIFF
--- a/frontend/cypress/e2e/search.cy.js
+++ b/frontend/cypress/e2e/search.cy.js
@@ -12,6 +12,13 @@ describe("Search feature", () => {
       .contains(/there are no occupations/i)
       .should("be.visible")
     SearchPage.resultsLabel().contains(0)
+
+    SearchPage.searchBar().clear().type('.')
+    SearchPage.searchButton().click()
+    cy.get('p')
+      .contains(/enter search terms/i)
+      .should("be.visible")
+    SearchPage.resultsLabel().contains('.')
   })
 
   it("prompts the user for input if there is no query available", () => {

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,7 +20,6 @@ function App() {
 
   const handleSavedSearchClick= (url) =>{
     setSearchQuery('');
-    console.log(url)
     const route = url.match(/^https?:\/\/[^/]+(\/.*)$/)[1];
     navigate(route);
 ;
@@ -48,7 +47,7 @@ function App() {
   }, [searchQuery])
 
   const handleQuery = input => {
-    setSearchQuery(input)
+    setSearchQuery(input.replace(/^\s+/g, ''))
   }
 
   return (

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -18,12 +18,17 @@ function App() {
   const [searchResults, setSearchResults] = useState([])
   const navigate = useNavigate()
 
-  const handleSavedSearchClick= (url) =>{
-    setSearchQuery('');
-    const route = url.match(/^https?:\/\/[^/]+(\/.*)$/)[1];
-    navigate(route);
-;
-    }
+  const handleSavedSearchClick = url => {
+    setSearchQuery("")
+    const route = url.match(/^https?:\/\/[^/]+(\/.*)$/)[1]
+    navigate(route)
+  }
+
+  const handleEmptyQuery = () => {
+    setSearchStatus("idle")
+    setSearchResults([])
+    navigate("/search")
+  }
 
   useEffect(() => {
     const handleSearch = async () => {
@@ -34,9 +39,7 @@ function App() {
         setSearchStatus("fulfilled")
         navigate("/search")
       } catch (error) {
-        setSearchStatus("idle")
-        setSearchResults([])
-        navigate("/search")
+        handleEmptyQuery()
       }
     }
 
@@ -48,7 +51,10 @@ function App() {
   }, [searchQuery])
 
   const handleQuery = input => {
-    setSearchQuery(input.replace(/^\s+/g, ''))
+    if (!input) {
+      return handleEmptyQuery()
+    }
+    setSearchQuery(input.replace(/^\s+/g, ""))
   }
 
   return (
@@ -65,11 +71,11 @@ function App() {
             path="/search"
             element={
               <Search
-              searchResults={searchResults}
-              searchStatus={searchStatus}
-              searchQuery={searchQuery}
-              setSearchQuery={setSearchQuery}
-              handleSavedSearchClick={handleSavedSearchClick}
+                searchResults={searchResults}
+                searchStatus={searchStatus}
+                searchQuery={searchQuery}
+                setSearchQuery={setSearchQuery}
+                handleSavedSearchClick={handleSavedSearchClick}
               />
             }
           />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -35,6 +35,7 @@ function App() {
         navigate("/search")
       } catch (error) {
         setSearchStatus("idle")
+        setSearchResults([])
         navigate("/search")
       }
     }

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -61,21 +61,23 @@ export default function Search({
       return setFilterOptions(selectedOptions)
     }
     setFilterOptions([])
-    setIsSaved(false)
+    setIsSaved(false);
   }
 
   const saveHandler = () => {
+    const currentFilterLength = filterOptions.length
+    const currentUrl = window.location.href
     const currentQuery = searchParams.get("query")
-    const currentEntry = retrieveLocalStorage(currentQuery)
-
-    if (currentEntry === null) return
-
+    const currentEntry = {
+      name: `${currentQuery} filters(${currentFilterLength})`,
+      url: currentUrl,
+    }
     setIsSaved(previous => !previous)
     if (isSaved) {
       const newSavedHistory = allSaved.filter(
         search => search.url !== currentEntry.url
       )
-
+     
       return setAllSaved(newSavedHistory)
     }
 
@@ -98,27 +100,22 @@ export default function Search({
     <div className="search-page main">
       <div className="search-page--options-bar">
         <div>
-          <FilterButton
-            options={allRoutes}
-            onApply={handleApplyFilters}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            setFilterOptions={setFilterOptions}
-          />
-          <SaveSearchButton
-            onSave={saveHandler}
-            isSaved={isSaved}
-            isDisabled={!searchQuery}
-          />
-          <SavedSearches
-            savedSearches={allSaved}
-            setSearchQuery={setSearchQuery}
-            handleSavedSearchClick={handleSavedSearchClick}
-          />
+        <FilterButton
+          options={allRoutes}
+          onApply={handleApplyFilters}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          setFilterOptions={setFilterOptions}
+        />
+        <SaveSearchButton onSave={saveHandler} isSaved={isSaved} isDisabled={!searchQuery} />
+        <SavedSearches savedSearches={allSaved}
+        setSearchQuery={setSearchQuery}
+        handleSavedSearchClick={handleSavedSearchClick}
+        />
         </div>
         {searchQuery && (
           <p>
-            {filteredResults.length} matched results for {searchQuery}
+            {filteredResults.length} matched results for {searchQuery.replaceAll(",+", " and ").replaceAll(",", " and ")}
           </p>
         )}
       </div>

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -61,23 +61,21 @@ export default function Search({
       return setFilterOptions(selectedOptions)
     }
     setFilterOptions([])
-    setIsSaved(false);
+    setIsSaved(false)
   }
 
   const saveHandler = () => {
-    const currentFilterLength = filterOptions.length
-    const currentUrl = window.location.href
     const currentQuery = searchParams.get("query")
-    const currentEntry = {
-      name: `${currentQuery} filters(${currentFilterLength})`,
-      url: currentUrl,
-    }
+    const currentEntry = retrieveLocalStorage(currentQuery)
+
+    if (currentEntry === null) return
+
     setIsSaved(previous => !previous)
     if (isSaved) {
       const newSavedHistory = allSaved.filter(
         search => search.url !== currentEntry.url
       )
-     
+
       return setAllSaved(newSavedHistory)
     }
 
@@ -100,18 +98,23 @@ export default function Search({
     <div className="search-page main">
       <div className="search-page--options-bar">
         <div>
-        <FilterButton
-          options={allRoutes}
-          onApply={handleApplyFilters}
-          searchQuery={searchQuery}
-          setSearchQuery={setSearchQuery}
-          setFilterOptions={setFilterOptions}
-        />
-        <SaveSearchButton onSave={saveHandler} isSaved={isSaved} isDisabled={!searchQuery} />
-        <SavedSearches savedSearches={allSaved}
-        setSearchQuery={setSearchQuery}
-        handleSavedSearchClick={handleSavedSearchClick}
-        />
+          <FilterButton
+            options={allRoutes}
+            onApply={handleApplyFilters}
+            searchQuery={searchQuery}
+            setSearchQuery={setSearchQuery}
+            setFilterOptions={setFilterOptions}
+          />
+          <SaveSearchButton
+            onSave={saveHandler}
+            isSaved={isSaved}
+            isDisabled={!searchQuery}
+          />
+          <SavedSearches
+            savedSearches={allSaved}
+            setSearchQuery={setSearchQuery}
+            handleSavedSearchClick={handleSavedSearchClick}
+          />
         </div>
         {searchQuery && (
           <p>


### PR DESCRIPTION
# Description

**Closes #180**  

Empty search queries are now cleaned out before we attempt to fetch results.
When a search query is found invalid the number of results is reset to zero on the label displaying number of matches.

### Files changed

- `Search.jsx` - implement a util function that seems to have been lost from a previous merge. The behaviour of the code stays the same but this is a refactor that had been done previously. Also now updating the state of `searchResults` to reset it when the `searchStatus` becomes "idle"
- `App.js` - added simple `.replace()` methods to stop empty search queries from being run and packaged the logic that handles invalid search queries for re-use to guarantee we communicate the user the desired behaviour.

### UI changes

none

### Changes to Documentation

none

# Tests

Extended `search.cy.js` to test the behaviour of the page in the event of an invalid search query being entered.
