### PR TITLE
refactor: extract santizing logic into a util function and edit the r…

### DIFF
--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -3,6 +3,8 @@ import "../style/globals.css"
 import "../style/OccupationPage.css"
 import { useParams } from "react-router-dom"
 
+import sanitize from "../utils/sanitize"
+
 export default function OccupationPage({ searchResults }) {
   const params = useParams()
 
@@ -10,10 +12,7 @@ export default function OccupationPage({ searchResults }) {
     occupation => occupation.stdCode === params.occupation
   )
 
-  const occupationSummary = searchResults[index].summary.replace(
-    /<\/?p>/g,
-    ""
-  )
+  const occupationSummary = sanitize(searchResults[index].summary)
   return (
     <main className="occupation-page__main main">
       <div className="flex-col occupation-header">

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -1,0 +1,9 @@
+/**
+ *
+ * @param {string} input accepts any string value
+ * @returns {string} will output the string passed in after clearing away any HTML element tags from it. This function targets and removes any tags, including attribute declarations, from the text provided.
+ * @abstract the api we're working with includes in some fields HTML formatting backed directly into the strings returned to the frontend. This HTML includes style attributes that target classes inexistent in our code base. The sanitize function is designed to remove these details and provide only the clean text we need.
+ */
+export default function sanitize(input) {
+  return input.replaceAll(/(<(.*?)>)/g, "")
+}


### PR DESCRIPTION
## Description

**Closes #184**

Sanitised the return value for an occupations summary in our `/occupation-details` route. Where this text was previously being returned with some html element tags incorporated into it (stringified) it now returns as simple text with all element tags removed entirely.

### Files changed

- `OccupationPage.jsx` - extracted the previous logic to remove html tags from the text
- `utils/sanitize.js` - refactored the previously existing logic with a new regex pattern that targets all text within an open and closing chevron (< >) to be removed from the text. This clears out all HTML element tags and any attribute declarations within them.

### UI changes

This is the same search result as the one posted on the original ticket, now sanitized:
![Screenshot 2024-09-02 at 15 08 53](https://github.com/user-attachments/assets/d880b726-fc79-4bb2-b3d9-e73cedc02b7f)


### Changes to Documentation

none

# Tests

No new tests. All previous tests passing.
