### PR TITLE
#192/fetch details

### DIFF
--- a/backend/server/routes/getOccupationDetails.js
+++ b/backend/server/routes/getOccupationDetails.js
@@ -4,7 +4,7 @@ export default async function getOccupationDetails(stdCode) {
   if (typeof stdCode !== "string" || !stdCode)
     throw new Error("No valid code found")
 
-  const url = `${process.env.BASE_URL}/Occupations/${stdCode}?expand=occupation.summary%2C%20occupation.overview%2C%20occupation.products`
+  const url = `${process.env.BASE_URL}/Occupations/${stdCode}?expand=occupation.summary%2C%20occupation.overview%2C%20occupation.products%2C%20occupation.mapHierarchy`
 
   const options = {
     method: "GET",

--- a/backend/server/routes/getOccupationDetails.js
+++ b/backend/server/routes/getOccupationDetails.js
@@ -1,0 +1,28 @@
+import "dotenv/config"
+
+export default async function getOccupationDetails(stdCode) {
+  if (typeof stdCode !== "string" || !stdCode)
+    throw new Error("No valid code found")
+
+  const url = `${process.env.BASE_URL}/Occupations/${stdCode}?expand=occupation.summary%2C%20occupation.overview%2C%20occupation.products`
+
+  const options = {
+    method: "GET",
+    headers: {
+      accept: "application/json",
+      "X-API-KEY": process.env.API_KEY,
+    },
+  }
+
+  try {
+    const response = await fetch(url, options)
+    if (!response.ok) throw new Error("Error fetching data")
+
+    const data = await response.json()
+
+    return data
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}

--- a/backend/server/server.js
+++ b/backend/server/server.js
@@ -1,50 +1,57 @@
-
 import express from "express"
 import cors from "cors"
 
 import getAllRoutes from "./routes/getAllRoutes.js"
 import getRouteById from "./routes/getRouteById.js"
 import getOccupationByQuery from "./routes/getOccupationByQuery.js"
+import getOccupationDetails from "./routes/getOccupationDetails.js"
 
 const server = express()
 
 const corsOptions = {
-    origin: process.env.FRONTEND,
-    optionsSuccessStatus: 200,
+  origin: process.env.FRONTEND,
+  optionsSuccessStatus: 200,
 }
 
 server.use(cors(corsOptions))
 
 server.get("/getAllRoutes", async (req, res) => {
-    try {
-        const data = await getAllRoutes()
-        res.status(200).json(data)
-    } catch (error) {
-        res.status(500).json(error)
-    }
+  try {
+    const data = await getAllRoutes()
+    res.status(200).json(data)
+  } catch (error) {
+    res.status(500).json(error)
+  }
 })
 
 server.get("/getRouteById/:id", async (req, res) => {
-    const { id } = req.params
-    try {
-        const data = await getRouteById(id)
-        res.status(200).json(data)
-    } catch (error) {
-        res.status(500).json(error)
-    }
+  const { id } = req.params
+  try {
+    const data = await getRouteById(id)
+    res.status(200).json(data)
+  } catch (error) {
+    res.status(500).json(error)
+  }
 })
 
-server.get(
-    "/getOccupationByQuery/:query",
-    async (req, res) => {
-        const { query } = req.params
-        try {
-            const data = await getOccupationByQuery(query)
-            res.status(200).json(data)
-        } catch (error) {
-            res.status(500).json(error)
-        }
-    }
-)
+server.get("/getOccupationByQuery/:query", async (req, res) => {
+  const { query } = req.params
+  try {
+    const data = await getOccupationByQuery(query)
+    res.status(200).json(data)
+  } catch (error) {
+    res.status(500).json(error)
+  }
+})
+
+server.get("/getOccupationDetails/:stdCode", async (req, res) => {
+  const { stdCode } = req.params
+  try {
+    const data = await getOccupationDetails(stdCode)
+    res.status(200).json(data)
+  } catch (error) {
+    res.status(500).json(error)
+  }
+})
 
 export default server

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -1,5 +1,5 @@
 import spinner from "../images/loadingSpinner.svg"
 
 export default function LoadingSpinner() {
-  return <img src={spinner}></img>
+  return <img src={spinner} alt="spinner animation" className="loading-spinner"></img>
 }

--- a/frontend/src/components/LoadingSpinner.jsx
+++ b/frontend/src/components/LoadingSpinner.jsx
@@ -1,5 +1,5 @@
 import spinner from "../images/loadingSpinner.svg"
 
 export default function LoadingSpinner() {
-  return <img src={spinner} alt="spinner animation" className="loading-spinner"></img>
+  return <img src={spinner} alt="spinner animation" />
 }

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -22,7 +22,7 @@ export default function OccupationPage() {
       await fetchOccupationDetails(params.occupation)
         .then(fetchedOccupation => {
           setCurrentOccupation(fetchedOccupation)
-          setIsLoaded(true)
+          setIsLoaded(true) 
         })
         .catch(error => setIsLoaded(false))
     }
@@ -30,38 +30,46 @@ export default function OccupationPage() {
     fetchDetails()
   }, [searchResults, params])
 
-  return isLoaded ? (
+  return (
     <main className="occupation-page__main main">
-      <div className="flex-col occupation-header">
-        <h1>{currentOccupation.name}</h1>
-        <h2>
-          Level {currentOccupation.level} -{" "}
-          <i>{currentOccupation.mapHierarchy.technicalLevelName}</i>
-        </h2>
-        <p className="route-name">
-          {currentOccupation.mapHierarchy.routeName}
-        </p>
-      </div>
-      <div className="flex-col occupation-page__banner">
-        <h3>Overview:</h3>
-        <p>{currentOccupation.overview}</p>
-      </div>
-      <section className="occupation-page__section">
-        <h3>In Depth</h3>
-        <div />
-        <p className="occupation-page__summary">
-          {sanitize(currentOccupation.summary)}
-        </p>
-      </section>
-      <TLevelContainer products={currentOccupation.products} />
-      <div className="pathway-name">
-        <p>
-          <strong>Pathway name: </strong>
-          <span>{currentOccupation.mapHierarchy.pathwayName}</span>
-        </p>
-      </div>
+      {isLoaded ? (
+        <>
+          <div className="flex-col occupation-header">
+            <h1>{currentOccupation.name}</h1>
+            <h2>
+              Level {currentOccupation.level} -{" "}
+              <i>
+                {currentOccupation.mapHierarchy.technicalLevelName}
+              </i>
+            </h2>
+            <p className="route-name">
+              {currentOccupation.mapHierarchy.routeName}
+            </p>
+          </div>
+          <div className="flex-col occupation-page__banner">
+            <h3>Overview:</h3>
+            <p>{currentOccupation.overview}</p>
+          </div>
+          <section className="occupation-page__section">
+            <h3>In Depth</h3>
+            <div />
+            <p className="occupation-page__summary">
+              {sanitize(currentOccupation.summary)}
+            </p>
+          </section>
+          <TLevelContainer products={currentOccupation.products} />
+          <div className="pathway-name">
+            <p>
+              <strong>Pathway name: </strong>
+              <span>
+                {currentOccupation.mapHierarchy.pathwayName}
+              </span>
+            </p>
+          </div>
+        </>
+      ) : (
+        <LoadingSpinner />
+      )}
     </main>
-  ) : (
-    <LoadingSpinner />
   )
 }

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -71,7 +71,9 @@ export default function OccupationPage() {
           </div>
         </>
       ) : (
-        <LoadingSpinner />
+        <div className="occupation-page--loading-spinner">
+          <LoadingSpinner />
+        </div>
       )}
     </main>
   )

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -1,54 +1,67 @@
+import { useState, useEffect } from "react"
+import { useParams } from "react-router-dom"
+
 import TLevelContainer from "../components/TLevelContainer"
 import { useSearchContext } from "../context/searchContext"
 import "../style/globals.css"
 import "../style/OccupationPage.css"
-import { useParams } from "react-router-dom"
-
+import LoadingSpinner from "../components/LoadingSpinner"
 import sanitize from "../utils/sanitize"
+import fetchOccupationDetails from "../utils/fetchOccupationDetails"
 
 export default function OccupationPage() {
-  const params = useParams()
   const {
     searchState: { searchResults },
   } = useSearchContext()
+  const params = useParams()
+  const [currentOccupation, setCurrentOccupation] = useState(null)
+  const [isLoaded, setIsLoaded] = useState(false)
 
-  const index = searchResults.findIndex(
-    occupation => occupation.stdCode === params.occupation
-  )
+  useEffect(() => {
+    const fetchDetails = async () => {
+      await fetchOccupationDetails(params.occupation)
+        .then(fetchedOccupation => {
+          setCurrentOccupation(fetchedOccupation)
+          setIsLoaded(true)
+        })
+        .catch(error => setIsLoaded(false))
+    }
 
-  const occupationSummary = sanitize(searchResults[index].summary)
-  return (
+    fetchDetails()
+  }, [searchResults, params])
+
+  return isLoaded ? (
     <main className="occupation-page__main main">
       <div className="flex-col occupation-header">
-        <h1>{searchResults[index].name}</h1>
+        <h1>{currentOccupation.name}</h1>
         <h2>
-          Level {searchResults[index].level} -{" "}
-          <i>
-            {searchResults[index].mapHierarchy.technicalLevelName}
-          </i>
+          Level {currentOccupation.level} -{" "}
+          <i>{currentOccupation.level}</i>
         </h2>
         <p className="route-name">
-          {searchResults[index].mapHierarchy.routeName}
+          {/* {currentOccupation.mapHierarchy.routeName} */}
         </p>
       </div>
       <div className="flex-col occupation-page__banner">
         <h3>Overview:</h3>
-        <p>{searchResults[index].overview}</p>
+        <p>{currentOccupation.overview}</p>
       </div>
       <section className="occupation-page__section">
         <h3>In Depth</h3>
         <div />
         <p className="occupation-page__summary">
-          {occupationSummary}
+          {sanitize(currentOccupation.summary)}
         </p>
       </section>
-      <TLevelContainer products={searchResults[index].products} />
+      <TLevelContainer products={currentOccupation.products} />
       <div className="pathway-name">
         <p>
           <strong>Pathway name: </strong>
-          <span>{searchResults[index].mapHierarchy.pathwayName}</span>
+          {/* <span>{currentOccupation.mapHierarchy.pathwayName}</span> */}
         </p>
       </div>
     </main>
+  ) : (
+    <LoadingSpinner />
   )
 }

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -36,10 +36,10 @@ export default function OccupationPage() {
         <h1>{currentOccupation.name}</h1>
         <h2>
           Level {currentOccupation.level} -{" "}
-          <i>{currentOccupation.level}</i>
+          <i>{currentOccupation.mapHierarchy.technicalLevelName}</i>
         </h2>
         <p className="route-name">
-          {/* {currentOccupation.mapHierarchy.routeName} */}
+          {currentOccupation.mapHierarchy.routeName}
         </p>
       </div>
       <div className="flex-col occupation-page__banner">
@@ -57,7 +57,7 @@ export default function OccupationPage() {
       <div className="pathway-name">
         <p>
           <strong>Pathway name: </strong>
-          {/* <span>{currentOccupation.mapHierarchy.pathwayName}</span> */}
+          <span>{currentOccupation.mapHierarchy.pathwayName}</span>
         </p>
       </div>
     </main>

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -22,9 +22,12 @@ export default function OccupationPage() {
       await fetchOccupationDetails(params.occupation)
         .then(fetchedOccupation => {
           setCurrentOccupation(fetchedOccupation)
-          setIsLoaded(true) 
+          setIsLoaded(true)
         })
-        .catch(error => setIsLoaded(false))
+        .catch(error => {
+          console.error(error)
+          setIsLoaded(false)
+        })
     }
 
     fetchDetails()

--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -40,14 +40,8 @@ export default function OccupationPage() {
           <div className="flex-col occupation-header">
             <h1>{currentOccupation.name}</h1>
             <h2>
-              Level {currentOccupation.level} -{" "}
-              <i>
-                {currentOccupation.mapHierarchy.technicalLevelName}
-              </i>
+              <i>{currentOccupation.mapHierarchy.pathwayName}</i>
             </h2>
-            <p className="route-name">
-              {currentOccupation.mapHierarchy.routeName}
-            </p>
           </div>
           <div className="flex-col occupation-page__banner">
             <h3>Overview:</h3>
@@ -61,14 +55,6 @@ export default function OccupationPage() {
             </p>
           </section>
           <TLevelContainer products={currentOccupation.products} />
-          <div className="pathway-name">
-            <p>
-              <strong>Pathway name: </strong>
-              <span>
-                {currentOccupation.mapHierarchy.pathwayName}
-              </span>
-            </p>
-          </div>
         </>
       ) : (
         <div className="occupation-page--loading-spinner">

--- a/frontend/src/style/OccupationPage.css
+++ b/frontend/src/style/OccupationPage.css
@@ -53,7 +53,7 @@
   padding-right: 1rem;
 }
 
-.loading-spinner {
+.occupation-page--loading-spinner {
   position: absolute;
   top:20%;
   left:50%;

--- a/frontend/src/style/OccupationPage.css
+++ b/frontend/src/style/OccupationPage.css
@@ -1,6 +1,7 @@
 .occupation-page__main {
   display: grid;
   grid-template-columns: 1fr;
+  align-items:first baseline;
 }
 
 .occupation-header h1 {
@@ -45,14 +46,6 @@
   grid-column: 1 / 3;
 }
 
-.pathway-name {
-  grid-column: 1 / 3;
-  width: 100%;
-  justify-content: flex-end;
-  margin: 1rem 0;
-  padding-right: 1rem;
-}
-
 .occupation-page--loading-spinner {
   position: absolute;
   top:20%;
@@ -76,12 +69,6 @@
   .occupation-page__section {
     grid-column: 1 / 7;
     padding: 0 4rem;
-  }
-
-  .pathway-name {
-    grid-column: 1 / 6;
-    padding-right: 0;
-    margin-bottom: 1rem;
   }
 }
 
@@ -113,12 +100,6 @@
     grid-column: 2 / 8;
     padding: 0;
   }
-
-  .pathway-name {
-    grid-column: 2 / 5;
-    justify-content: flex-start;
-    padding-bottom: 1rem;
-  }
 }
 
 @media (min-width: 2000px) {
@@ -134,9 +115,5 @@
   .occupation-page__section {
     grid-column: 2 / 9;
     padding: 0 6rem;
-  }
-
-  .pathway-name {
-    grid-column: 1 / 8;
   }
 }

--- a/frontend/src/style/OccupationPage.css
+++ b/frontend/src/style/OccupationPage.css
@@ -53,7 +53,11 @@
   padding-right: 1rem;
 }
 
-
+.loading-spinner {
+  position: absolute;
+  top:20%;
+  left:50%;
+}
 
 @media (min-width: 800px) {
   .occupation-page__main {

--- a/frontend/src/utils/fetchOccupationDetails.js
+++ b/frontend/src/utils/fetchOccupationDetails.js
@@ -1,3 +1,10 @@
+/**
+ * 
+ * @abstract this util calls the api for the full details of any given occupation to be displayed in `/occupation-details`
+ * @param {string} givenCode expects the stdCode of an occupation present in the api data
+ * @returns the stringified object of the targeted occupation
+ * @throws if our server cannot find the given code of if the code is not a valid string
+ */
 export default async function fetchOccupationDetails(givenCode) {
   try {
     const data = await fetch(

--- a/frontend/src/utils/fetchOccupationDetails.js
+++ b/frontend/src/utils/fetchOccupationDetails.js
@@ -1,0 +1,13 @@
+export default async function fetchOccupationDetails(givenCode) {
+  try {
+    const data = await fetch(
+      `${process.env.REACT_APP_SERVER}/getOccupationDetails/${givenCode}`
+    )
+    const parsedData = await data.json()
+
+    return parsedData
+  } catch (error) {
+    console.error(error)
+    throw error
+  }
+}


### PR DESCRIPTION
# Description

**Closes #192**  

Adds a new endpoint to our backend to fetch data from the api and serves this on the front to `/occupation-details`

### Files changed

- `backend/server/routes/getOccupationDetails`, `server.js`, frontend/src/utils/fetchOccupationDetails` - serving a new endpoint that fetches the details of a specific occupation from the api
- `OccupationPage.jsx`, `OccupationPage.css` & `LoadingSpinner.jsx` - edited the `/occupation-details/:occupation` page to load data for the occupation with the `stdCode` passed in params and edited the display to render a loading spinner while processing this fetch call

### UI changes

Looks exactly the same, apart from a spinner at the centre of the page in `/occupation-details/:occupation` when loading
![Screenshot 2024-09-04 at 13 00 15](https://github.com/user-attachments/assets/12e8b417-2044-4749-aa63-393c01018fa0)


### Changes to Documentation

None

# Tests

No new tests as the behaviour is the same as intended before. All tests are passing.
