### PR TITLE
#184/refactor sanitize

### DIFF
--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -38,9 +38,10 @@ export default function OccupationPage() {
       <section className="occupation-page__section">
         <h3>In Depth</h3>
         <div />
-        <p className="occupation-page__summary">
-          {occupationSummary}
-        </p>
+        <div
+          className="occupation-page__summary"
+          dangerouslySetInnerHTML={{ __html: occupationSummary }}
+        />
       </section>
       <TLevelContainer products={searchResults[index].products} />
       <div className="pathway-name">

--- a/frontend/src/style/OccupationPage.css
+++ b/frontend/src/style/OccupationPage.css
@@ -53,7 +53,12 @@
   padding-right: 1rem;
 }
 
-
+.occupation-page__summary {
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: start;
+}
 
 @media (min-width: 800px) {
   .occupation-page__main {

--- a/frontend/src/utils/sanitize.js
+++ b/frontend/src/utils/sanitize.js
@@ -5,5 +5,5 @@
  * @abstract the api we're working with includes in some fields HTML formatting backed directly into the strings returned to the frontend. This HTML includes style attributes that target classes inexistent in our code base. The sanitize function is designed to remove these details and provide only the clean text we need.
  */
 export default function sanitize(input) {
-  return input.replaceAll(/(<(.*?)>)/g, "")
+  return input.replaceAll(/<(^\/?)(.*?)>/g, "")
 }


### PR DESCRIPTION
# Description

**Relates #184 **  

This PR is referencing a previously closed issue because it's a refactor of the work done there based on my recent look through the data returned from our api.

The summary property for occupations returned is a string with html element tags integrated. We previously removed all html tags from the text alongside the styling and all attributes declared there. I've now altered the sanitize function so that it removes any attribute declarations but keeps the element tags in the text.

This, in conjunction with our normalised css is now rendering the text with different paragraphs, a few unordered lists and some links, creating a much more easily readable summary.

### Files changed

- `utils/sanitize.js` - edited the RegEx in the replaceAll function to allow element tags to be kept in the return value.
- `OccupationPage.jsx` && `OccupationPage.css` - inserting the summary string html onto a `div` and styling the `.occupation-page__summary` class to align all elements returned.

### UI changes

<img width="1449" alt="Screenshot 2024-09-04 at 15 30 14" src="https://github.com/user-attachments/assets/50a7cd8f-539b-450d-b5b6-23952abe8c44">


### Changes to Documentation

none

# Tests

No new tests. All previous tests passing.
