### PR TITLE
#178/save edge cases

### DIFF
--- a/frontend/cypress/e2e/save.cy.js
+++ b/frontend/cypress/e2e/save.cy.js
@@ -51,7 +51,7 @@ describe("allows the user to view previously saved searches", () => {
     cy.get(".saved-searches__dropdown").should("be.visible")
 
     cy.get(".dropdown-item")
-      .contains("web developer filters(0)")
+      .contains(/web developer/i)
       .should("exist")
       .should("be.visible")
       .click()

--- a/frontend/cypress/e2e/search.cy.js
+++ b/frontend/cypress/e2e/search.cy.js
@@ -49,6 +49,6 @@ describe("Search feature", () => {
     cy.get("div")
       .contains(/teaching assistant/i)
       .should("be.visible")
-    SearchPage.resultsLabel().contains(/teacher and web developer/i).contains(3)
+    SearchPage.resultsLabel().contains(/teacher, web developer/i).contains(3)
   })
 })

--- a/frontend/src/components/FilterButton.jsx
+++ b/frontend/src/components/FilterButton.jsx
@@ -34,7 +34,7 @@ export default function FilterButton({ options, onApply,searchQuery, setSearchQu
      const queryRegex = /[?&]query=([^&]+)/;
      
  const match = currentUrl.match(queryRegex);
- dispatch({type: "SET_SEARCH_QUERY", payload: match ? decodeURIComponent(match[1]) : null})
+ dispatch({type: "SET_SEARCH_QUERY", payload: match ? decodeURIComponent(match[1]) : ""})
  const filterRegex = /[?&]filter=(\d+)/g;
  const newOptions = [...currentUrl.matchAll(filterRegex)].map(match => parseInt(match[1]))
  

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { useEffect, useState } from "react"
 
 import { useSearchContext } from "../context/searchContext"
@@ -9,6 +9,7 @@ import "../style/Header.css"
 export default function Header() {
   const { dispatch } = useSearchContext()
   const [currentPage, setCurrentPage] = useState()
+  const navigate = useNavigate()
 
   useEffect(() => {
     const page = window.location.href
@@ -19,6 +20,7 @@ export default function Header() {
   }, [window.location.href])
 
   const searchHandler = input => {
+    if (!input) return navigate("/search")
     dispatch({ type: "SET_SEARCH_QUERY", payload: input })
   }
 

--- a/frontend/src/components/TextSearch.jsx
+++ b/frontend/src/components/TextSearch.jsx
@@ -1,8 +1,12 @@
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { useSearchContext } from "../context/searchContext"
 import "../style/TextSearch.css"
 
 export default function TextSearch({ searchHandler }) {
-  const [searchParameter, setSearchParameter] = useState(undefined)
+  const [searchParameter, setSearchParameter] = useState()
+  const {
+    searchState: { searchQuery },
+  } = useSearchContext()
 
   const inputHandler = event => {
     setSearchParameter(event.target.value)
@@ -12,6 +16,12 @@ export default function TextSearch({ searchHandler }) {
     event.preventDefault()
     searchHandler(searchParameter)
   }
+
+  useEffect(() => {
+    if (searchQuery === searchParameter) return
+    setSearchParameter(searchQuery)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchQuery])
 
   return (
     <>

--- a/frontend/src/context/searchStore.js
+++ b/frontend/src/context/searchStore.js
@@ -3,7 +3,7 @@ export default function searchReducer(state, action) {
     case "SET_SEARCH_STATUS":
       return { ...state, searchStatus: action.payload }
     case "SET_SEARCH_QUERY":
-      return { ...state, searchQuery: action.payload.replaceAll(/\+/g, " ") }
+      return { ...state, searchQuery: action.payload === "" ?? action.payload.replaceAll(/\+/g, " ") }
     case "SET_SEARCH_RESULTS":
       return { ...state, searchResults: action.payload }
     default:

--- a/frontend/src/context/searchStore.js
+++ b/frontend/src/context/searchStore.js
@@ -3,7 +3,7 @@ export default function searchReducer(state, action) {
     case "SET_SEARCH_STATUS":
       return { ...state, searchStatus: action.payload }
     case "SET_SEARCH_QUERY":
-      return { ...state, searchQuery: action.payload }
+      return { ...state, searchQuery: action.payload.replaceAll(/\+/g, " ") }
     case "SET_SEARCH_RESULTS":
       return { ...state, searchResults: action.payload }
     default:

--- a/frontend/src/context/searchStore.js
+++ b/frontend/src/context/searchStore.js
@@ -3,7 +3,7 @@ export default function searchReducer(state, action) {
     case "SET_SEARCH_STATUS":
       return { ...state, searchStatus: action.payload }
     case "SET_SEARCH_QUERY":
-      return { ...state, searchQuery: action.payload === "" ?? action.payload.replaceAll(/\+/g, " ") }
+      return { ...state, searchQuery: action.payload ? action.payload.replaceAll(/\+/g, " ") : ""}
     case "SET_SEARCH_RESULTS":
       return { ...state, searchResults: action.payload }
     default:

--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -4,39 +4,39 @@ import "../style/About.css"
 export default function About() {
   return (
     <main className="about-page-container">
-        <img
-          className="about-page__image about-page-container__element"
-          src={youngProfessionals}
-        />
-        <div className="about-page-container__element">
-          <p>
-            Apprenticeships, T Levels and other technical
-            qualifications draw their content from occupational
-            standards set out by employers. Training is structured
-            around occupations so that individuals can develop the
-            knowledge, skills and behaviour they need to do well in
-            those roles. In many cases these occupations are found
-            across multiple sectors in the labour market. For example,
-            software engineers work for banks as part of the finance
-            sector, and there are finance roles such as payroll and
-            accounts assistants working in the health or retail
-            sectors. Thus individual T Levels feed into multiple
-            sectors – there are a range of possibilities for students
-            to progress into, and pathways for
-          </p>
-          <p>
-            This tool enables users - including employers and local
-            stakeholders, such as local authorities - to visualise the
-            occupations that make up the sectors they operate in,
-            identify the technical education pathways and specific T
-            Levels that feed into these sectors. Employers can input
-            the occupations they have in their business and see the T
-            Level pathways that link to these roles. This will help
-            employers determine where they can start building their
-            workforce pipelines, for example by beginning to host T
-            Level industry placements in these
-          </p>
-        </div>
+      <img
+        className="about-page__image about-page-container__element"
+        src={youngProfessionals}
+      />
+      <div className="about-page-container__element">
+        <p>
+          Apprenticeships, T Levels and other technical qualifications
+          draw their content from occupational standards set out by
+          employers. Training is structured around occupations so that
+          individuals can develop the knowledge, skills and behaviour
+          they need to do well in those roles. In many cases these
+          occupations are found across multiple sectors in the labour
+          market. For example, software engineers work for banks as
+          part of the finance sector, and there are finance roles such
+          as payroll and accounts assistants working in the health or
+          retail sectors. Thus individual T Levels feed into multiple
+          sectors – there are a range of possibilities for students to
+          progress into, and pathways for students to progress into,
+          and pathways for employers to recruit from.
+        </p>
+        <p>
+          This tool enables users - including employers and local
+          stakeholders, such as local authorities - to visualise the
+          occupations that make up the sectors they operate in,
+          identify the technical education pathways and specific T
+          Levels that feed into these sectors. Employers can input the
+          occupations they have in their business and see the T Level
+          pathways that link to these roles. This will help employers
+          determine where they can start building their workforce
+          pipelines, for example by beginning to host T Level industry
+          placements in these pathways.
+        </p>
+      </div>
     </main>
   )
 }

--- a/frontend/src/pages/Search.jsx
+++ b/frontend/src/pages/Search.jsx
@@ -10,9 +10,7 @@ import SavedSearches from "../components/SavedSearch"
 import "../style/Search.css"
 import { useSearchContext } from "../context/searchContext"
 
-export default function Search({
-  handleSavedSearchClick,
-}) {
+export default function Search({ handleSavedSearchClick }) {
   const [searchParams, setSearchParams] = useSearchParams()
   const [isSaved, setIsSaved] = useState(false)
   const [allSaved, setAllSaved] = useState(
@@ -26,6 +24,12 @@ export default function Search({
     useState(searchResults)
   const [filterOptions, setFilterOptions] = useState([])
 
+  const verifyIsSaved = () => {
+    const currentUrl = window.location.href.replaceAll(/\+/g, " ")
+    const allUrls = new Set(allSaved.map(search => search.url))
+    return allUrls.has(currentUrl)
+  }
+
   useEffect(() => {
     const fetchOptions = async () => {
       const filterOptions = await fetchAllRoutes()
@@ -35,9 +39,7 @@ export default function Search({
 
     searchQuery &&
       setSearchParams({ query: searchQuery, filter: filterOptions })
-    const currentUrl = window.location.href
-    const allUrls = new Set(allSaved.map(search => search.url))
-    setIsSaved(allUrls.has(currentUrl))
+    setIsSaved(verifyIsSaved())
     // eslint-disable-next-line react-hooks/exhaustive-deps
 
     if (filterOptions && filterOptions.length > 0) {
@@ -68,8 +70,8 @@ export default function Search({
     const currentUrl = window.location.href
     const currentQuery = searchParams.get("query")
     const currentEntry = {
-      name: `${currentQuery} filters(${currentFilterLength})`,
-      url: currentUrl,
+      name: `${currentQuery} ${currentFilterLength > 0 ? `filters(${currentFilterLength})` : ""}`,
+      url: currentUrl.replaceAll(/\+/g, " "),
     }
     setIsSaved(previous => !previous)
     if (isSaved) {
@@ -117,7 +119,7 @@ export default function Search({
         </div>
         {searchQuery && (
           <p>
-            {filteredResults.length} matched results for {searchQuery.replaceAll(",+", " and ").replaceAll(",", " and ")}
+            {filteredResults.length} matched results for {searchQuery}
           </p>
         )}
       </div>

--- a/frontend/src/style/SavedSearch.css
+++ b/frontend/src/style/SavedSearch.css
@@ -65,6 +65,7 @@ a p {
   border:none;
   text-wrap:wrap;
   cursor:pointer;
+  text-align:start;
 }
 
 .dropdown-item:hover {


### PR DESCRIPTION
# Description

**Closes #178 **  

Saving any searches with a space in the query (for example `assistant manager`) was causing the saved searches functionality to break. This pr fixes that and also makes a few simple UI adjustments that came out of the latest catch up with Gatsby.

### Files changed

- `cypress/**.cy.js` - adjusted test suites to match the new expected behaviour
- `Search.jsx`, `/components/**` - added logic to clean string values of urls being saved to avoid false mismatches when updating `isSaved` status in `Search.jsx`
- `searchStore.js` - edited reducer logic for setting search query
- `About.jsx` - updated copy that was incomplete from the client's spec.

### UI changes

Looks the same

### Changes to Documentation

None

# Tests

All tests passing. Some assertions were edited but no new tests.
