### PR TITLE
fix: add default value for summary display

### DIFF
--- a/frontend/src/pages/OccupationPage.jsx
+++ b/frontend/src/pages/OccupationPage.jsx
@@ -51,8 +51,14 @@ export default function OccupationPage() {
             <h3>In Depth</h3>
             <div />
             <div
-          className="occupation-page__summary"
-              dangerouslySetInnerHTML={{ __html: sanitize(currentOccupation.summary) }}
+              className="occupation-page__summary"
+              dangerouslySetInnerHTML={{
+                __html: sanitize(
+                  currentOccupation.summary === ""
+                    ? "<p>No summary provided. Please visit the T-Level placement links provided for more information.</p>"
+                    : currentOccupation.summary
+                ),
+              }}
             />
           </section>
           <TLevelContainer products={currentOccupation.products} />


### PR DESCRIPTION
rlates #210

# Description

**Closes #210**  

Added a ternary to return a default message if the value of `summary` is an empty string. To replicate the error search 'project manager' and open the occupation returned.

### Files changed

- 'OccupationPage.jsx`

### UI changes

![Screenshot 2024-09-09 at 14 36 11](https://github.com/user-attachments/assets/142078c9-0677-4fce-98d9-5ac56cd04e0c)

### Changes to Documentation

none

# Tests

none. all previous tests passing
