### PR TITLE
style: split copy into smaller paragraphs

### DIFF
--- a/frontend/src/pages/About.jsx
+++ b/frontend/src/pages/About.jsx
@@ -14,27 +14,35 @@ export default function About() {
           draw their content from occupational standards set out by
           employers. Training is structured around occupations so that
           individuals can develop the knowledge, skills and behaviour
-          they need to do well in those roles. In many cases these
-          occupations are found across multiple sectors in the labour
-          market. For example, software engineers work for banks as
-          part of the finance sector, and there are finance roles such
-          as payroll and accounts assistants working in the health or
-          retail sectors. Thus individual T Levels feed into multiple
-          sectors – there are a range of possibilities for students to
-          progress into, and pathways for students to progress into,
-          and pathways for employers to recruit from.
+          they need to do well in those roles.
+        </p>
+        <p>
+          In many cases these occupations are found across multiple
+          sectors in the labour market. For example, software
+          engineers work for banks as part of the finance sector, and
+          there are finance roles such as payroll and accounts
+          assistants working in the health or retail sectors.
+        </p>
+        <p>
+          Thus individual T Levels feed into multiple sectors – there
+          are a range of possibilities for students to progress into,
+          and pathways for students to progress into, and pathways for
+          employers to recruit from.
         </p>
         <p>
           This tool enables users - including employers and local
           stakeholders, such as local authorities - to visualise the
           occupations that make up the sectors they operate in,
           identify the technical education pathways and specific T
-          Levels that feed into these sectors. Employers can input the
-          occupations they have in their business and see the T Level
-          pathways that link to these roles. This will help employers
-          determine where they can start building their workforce
-          pipelines, for example by beginning to host T Level industry
-          placements in these pathways.
+          Levels that feed into these sectors.
+        </p>
+        <p>
+          Employers can input the occupations they have in their
+          business and see the T Level pathways that link to these
+          roles. This will help employers determine where they can
+          start building their workforce pipelines, for example by
+          beginning to host T Level industry placements in these
+          pathways.
         </p>
       </div>
     </main>


### PR DESCRIPTION
relates #214

# Description

**Closes #214**  

Break down copy in the `about` page into smaller paragraphs.

### Files changed

- About.jsx

### UI changes

<img width="1378" alt="Screenshot 2024-09-09 at 17 39 04" src="https://github.com/user-attachments/assets/98e40544-9b6f-406c-bfca-b12cce63f35a">


### Changes to Documentation

none

# Tests

no changes to the behaviour of the code. all previous tests passing
