### PR TITLE
#213/fix navigation

### DIFF
--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -22,6 +22,7 @@ export default function Header() {
   const searchHandler = input => {
     if (!input) return navigate("/search")
     dispatch({ type: "SET_SEARCH_QUERY", payload: input })
+    navigate('/search')
   }
 
   return (
@@ -39,7 +40,7 @@ export default function Header() {
           About
         </Link>
         <Link
-          className={`header-button ${currentPage === "search" && "bold"}`}
+          className={`header-button ${currentPage === "search" | currentPage === "occupation-details" && "bold"}`}
           to="/search"
         >
           {currentPage === 'occupation-details' ? "Back" : "Search"}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -13,7 +13,7 @@ export default function Header() {
 
   useEffect(() => {
     const page = window.location.href
-    const pageRegex = /(about)|(search)/g
+    const pageRegex = /(about)|(search)|(occupation-details)/g
     const match = page.match(pageRegex)
 
     setCurrentPage(match ? match[0] : "/")
@@ -42,7 +42,7 @@ export default function Header() {
           className={`header-button ${currentPage === "search" && "bold"}`}
           to="/search"
         >
-          Search
+          {currentPage === 'occupation-details' ? "Back" : "Search"}
         </Link>
       </nav>
       <TextSearch searchHandler={searchHandler} />

--- a/frontend/src/style/Header.css
+++ b/frontend/src/style/Header.css
@@ -33,6 +33,7 @@
 
 .header-button {
   text-decoration: none;
+  width:55px;
 }
 
 .header-button:hover {


### PR DESCRIPTION
# Description

**Closes #213**  

Conditionally render the 'search' button on the header as a 'back' button when we navigate to `/occupation-details`

### Files changed

- `Header.jsx` and `Header.css` - styling the 'search' button and conditionally render the button title depending on the current page. Also added navigation when we enter a search query in the text search regardless of whether it is updating the state.

### UI changes

If this PR includes changes to the UI include a **screengrab** of the alterations in review.

### Changes to Documentation

<img width="1331" alt="Screenshot 2024-09-09 at 18 00 05" src="https://github.com/user-attachments/assets/c21bc6db-cf84-4b73-a3b2-e139b267f2e6">


# Tests

no new tests. all previous tests passing.
