### PR TITLE
style: allow scrolling of saved search titles

### DIFF
--- a/frontend/src/components/SavedSearch.jsx
+++ b/frontend/src/components/SavedSearch.jsx
@@ -45,17 +45,19 @@ export default function SavedSearches({
             <div className="divider" />
           </div>
 
-          {savedSearches.map((search, index) => (
-            <button
-              key={`today-${index}`}
-              className="dropdown-item"
-              onClick={() => handleSavedSearchClick(search.url)}
-            >
-              {search.name
-                .replaceAll(",+", " and ")
-                .replaceAll(",", " and ")}
-            </button>
-          ))}
+          <div className="saved-searches__dropdown-links-container">
+            {savedSearches.map((search, index) => (
+              <button
+                key={`today-${index}`}
+                className="dropdown-item"
+                onClick={() => handleSavedSearchClick(search.url)}
+              >
+                {search.name
+                  .replaceAll(",+", " and ")
+                  .replaceAll(",", " and ")}
+              </button>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/frontend/src/style/SavedSearch.css
+++ b/frontend/src/style/SavedSearch.css
@@ -68,6 +68,7 @@
   border: none;
   text-wrap: wrap;
   cursor: pointer;
+  text-align: start;
 }
 
 .dropdown-item:hover {

--- a/frontend/src/style/SavedSearch.css
+++ b/frontend/src/style/SavedSearch.css
@@ -34,6 +34,11 @@
   display: flex;
 }
 
+.saved-searches__dropdown-links-container {
+  max-height: 300px;
+  overflow: auto;
+}
+
 .divider-container {
   display: flex;
   align-items: center;


### PR DESCRIPTION
relates #219

# Description

**Closes #219**  

### Files changed

- `SavedSearch.jsx` && `SavedSearch.css` - wrapped all saved search links in a new container with a set max-height and auto overflow. The divider on the save searches list stays at the top while the list of saved searches can now be scrolled through.

### UI changes

This is the maximum height the container can take now. Any additional searches can be reached by scrolling through.

![Screenshot 2024-09-11 at 10 02 20](https://github.com/user-attachments/assets/544d76ee-c6ff-425f-8cea-5efb51664c91)


### Changes to Documentation

none

# Tests

No new tests. All previous tests passing.
