### PR TITLE
fix: prevent hyfenated titles

### DIFF
--- a/frontend/src/components/OccupationCard.jsx
+++ b/frontend/src/components/OccupationCard.jsx
@@ -52,7 +52,7 @@ const [isMultiLine, setIsMultiLine]= useState(false);
       className="occupation-card"
       onClick={() => navigate(`/occupation-details/${stdCode}`)}
     >
-      <h2 ref={ref} className= {isMultiLine ? 'text-center' :'text-left'   } >{name}</h2>
+      <h2 ref={ref} className= {isMultiLine ? 'text-center' :'text-left'   } >{name.replace(/[\w+\s]*-/gi, "")}</h2>
     
         <div className="overview">
           <p className='in-brief'>


### PR DESCRIPTION
# Description

**Closes #223**  

Stopped occupation names from wrapping past two lines by removing any prefixed titles when the name 

### Files changed

- `OccupationCard.jsx` - editing occupation name property on render to target any text displayed before a hyfen and removing it.

### UI changes

#### This
![Screenshot 2024-09-11 at 10 39 27](https://github.com/user-attachments/assets/37a26b99-3ca0-4c7a-9153-606a52581e50)


#### Became this
![Screenshot 2024-09-11 at 10 38 48](https://github.com/user-attachments/assets/bec73f29-7006-47e9-9608-e40a26cdf6b0)



### Changes to Documentation

none

# Tests

No new tests. All previous tests passing
